### PR TITLE
fix: sentence tags to account for numbered lists

### DIFF
--- a/tts-highlighter.js
+++ b/tts-highlighter.js
@@ -69,7 +69,7 @@ var TtsHighlighter = {
             }
         }
 
-        this.text_element.innerHTML = processed_text;
+        this.text_element.innerHTML = processed_text + remaining_text;
     },
 
     /**


### PR DESCRIPTION
Addresses the issue of sentence matching in numbered lists by including remaining text for accurate word alignment preservation (by compromising the sentence highlighting on such cases, eg. numbered lists)